### PR TITLE
Search improvements

### DIFF
--- a/plugins/souk21/commandpalette/CommandPaletteSearchSteps.json
+++ b/plugins/souk21/commandpalette/CommandPaletteSearchSteps.json
@@ -1,8 +1,8 @@
 {
     "steps": [
-          {"filter": "[!is[system]search:title[]]", "hint": "in title", "caret": "25"},
-          {"filter": "[all[system+shadows]search:title[]]", "hint": "in title (system)", "caret": "33"},
-          {"filter": "[search[]]", "hint": "all", "caret": "8"},
-          {"filter": "[all[shadows]search[]]", "hint": "shadows", "caret": "20"}
+          {"filter": "[!is[system]search:title[%s]]", "hint": "in title"},
+          {"filter": "[all[system+shadows]search:title[%s]]", "hint": "in title (system)"},
+          {"filter": "[search[%s]]", "hint": "all"},
+          {"filter": "[all[shadows]search[%s]]", "hint": "shadows"}
     ]
 }

--- a/plugins/souk21/commandpalette/widgets_commandpalettewidget.js
+++ b/plugins/souk21/commandpalette/widgets_commandpalettewidget.js
@@ -13,6 +13,7 @@ Command Palette Widget
 	'use strict';
 
 	var Widget = require('$:/core/modules/widgets/widget.js').widget;
+	var Utils = require("$:/core/modules/utils/utils.js");
 
 	class CommandPaletteWidget extends Widget {
 		constructor(parseTreeNode, options) {
@@ -741,7 +742,17 @@ Command Palette Widget
 
 		searchStepBuilder(filter, caret, hint) {
 			return (terms) => {
-				let search = filter.substr(0, caret) + terms + filter.substr(caret);
+				let search = "";
+				if (caret) {
+					// Use legacy "caret" logic
+					search = filter.substr(0, caret) + terms + filter.substr(caret);
+				}
+				else if (filter.indexOf("regexp[") !== -1 || filter.indexOf("regexp:title[") !== -1) {
+					search = filter.replace("%s", Utils.escapeRegExp(terms));
+				}
+				else {
+					search = filter.replace("%s", terms);
+				}
 				let results = $tw.wiki.filterTiddlers(search).map(s => { return { name: s, hint: hint } });
 				return results;
 			}

--- a/plugins/souk21/commandpalette/widgets_commandpalettewidget.js
+++ b/plugins/souk21/commandpalette/widgets_commandpalettewidget.js
@@ -727,7 +727,14 @@ Command Palette Widget
 			}
 			else {
 				searches = this.searchSteps.reduce((a, c) => [...a, ...c(terms)], []);
-				searches = Array.from(new Set(searches));
+				let _unique = new Set();
+				// Filter search results to only get the first unique occurence of every tiddler name
+				searches = searches.filter(s => {
+					if (_unique.has(s.name))
+						return false;
+					_unique.add(s.name);
+					return true;
+				});
 			}
 			this.showResults(searches);
 		}

--- a/plugins/souk21/commandpalette/widgets_commandpalettewidget.js
+++ b/plugins/souk21/commandpalette/widgets_commandpalettewidget.js
@@ -748,10 +748,10 @@ Command Palette Widget
 					search = filter.substr(0, caret) + terms + filter.substr(caret);
 				}
 				else if (filter.indexOf("regexp") !== -1) {
-					search = filter.replace("%s", Utils.escapeRegExp(terms));
+					search = filter.replace(/%s/g, Utils.escapeRegExp(terms));
 				}
 				else {
-					search = filter.replace("%s", terms);
+					search = filter.replace(/%s/g, terms);
 				}
 				let results = $tw.wiki.filterTiddlers(search).map(s => { return { name: s, hint: hint } });
 				return results;

--- a/plugins/souk21/commandpalette/widgets_commandpalettewidget.js
+++ b/plugins/souk21/commandpalette/widgets_commandpalettewidget.js
@@ -747,7 +747,7 @@ Command Palette Widget
 					// Use legacy "caret" logic
 					search = filter.substr(0, caret) + terms + filter.substr(caret);
 				}
-				else if (filter.indexOf("regexp[") !== -1 || filter.indexOf("regexp:title[") !== -1) {
+				else if (filter.indexOf("regexp") !== -1) {
 					search = filter.replace("%s", Utils.escapeRegExp(terms));
 				}
 				else {


### PR DESCRIPTION
I have some suggestions for improvements:

1. Instead of using the "caret" logic for CommandPaletteSearchSteps, I suggest using a "%s"-based logic, where we use `string.replace()`. This is slower, but easier to work with.
2. If the filter contains "regexp[]" or "regexp:title[]" filter operators, escape the search terms to work inside a regular expression.
3. Make sure that the search results always contain each tiddler only once. Previously, the same tiddler could be listed as matching different "hints".

Personally, I think the search should first match the query by the beginning of words, and after that, look inside words. I have altered my personal CommandPaletteSearchSteps to do that with regular expressions, but I'm not sure this is wanted by default?

I also don't want images in my search results.

This is my current CommandPaletteSearchSteps:

```json
{
    "steps": [
          {"filter": "[!is[system]!is[image]regexp:title[(?i)\\b%s]]", "hint": "in title"},
          {"filter": "[!is[system]!is[image]search:title[%s]]", "hint": "in title"},
          {"filter": "[!is[system]!is[image]regexp:text[(?i)\\b%s]]", "hint": "fulltext"},
          {"filter": "[!is[system]!is[image]search:text[%s]]", "hint": "fulltext"},
          {"filter": "[!is[system]!is[image]search:*[%s]]", "hint": "fields"},
          {"filter": "[all[system+shadows]search:title[%s]]", "hint": "in title (system)"},
          {"filter": "[all[system+shadows]search:text[%s]]", "hint": "fulltext (system)"}
    ]
}
```