### PR TITLE
Search improvements (variation)

### DIFF
--- a/plugins/souk21/commandpalette/CommandPaletteSearchSteps.json
+++ b/plugins/souk21/commandpalette/CommandPaletteSearchSteps.json
@@ -1,8 +1,8 @@
 {
     "steps": [
-          {"filter": "[!is[system]search:title[%s]]", "hint": "in title"},
-          {"filter": "[all[system+shadows]search:title[%s]]", "hint": "in title (system)"},
-          {"filter": "[search[%s]]", "hint": "all"},
-          {"filter": "[all[shadows]search[%s]]", "hint": "shadows"}
+          {"filter": "[!is[system]search:title<query>]", "queryTransformFilter": "", "hint": "in title"},
+          {"filter": "[all[system+shadows]search:title<query>]", "queryTransformFilter": "", "hint": "in title (system)"},
+          {"filter": "[search<query>]", "queryTransformFilter": "", "hint": "all"},
+          {"filter": "[all[shadows]search<query>]", "queryTransformFilter": "", "hint": "shadows"}
     ]
 }

--- a/plugins/souk21/commandpalette/CommandPaletteSearchSteps.json
+++ b/plugins/souk21/commandpalette/CommandPaletteSearchSteps.json
@@ -1,8 +1,8 @@
 {
     "steps": [
-          {"filter": "[!is[system]search:title[]]", "hint": "in title", "caret": "25"},
-          {"filter": "[all[system+shadows]search:title[]]", "hint": "in title (system)", "caret": "33"},
-          {"filter": "[search[]]", "hint": "all", "caret": "8"},
-          {"filter": "[all[shadows]search[]]", "hint": "shadows", "caret": "20"}
+          {"filter": "[!is[system]search:title[%s]]", "hint": "in title"},
+          {"filter": "[all[system+shadows]search:title[%s]]", "hint": "in title (system)"},
+          {"filter": "[search[%s]]", "hint": "all"},
+          {"filter": "[all[shadows]search[%s]]", "hint": "shadows"}
     ]
 }

--- a/plugins/souk21/commandpalette/widgets_commandpalettewidget.js
+++ b/plugins/souk21/commandpalette/widgets_commandpalettewidget.js
@@ -13,6 +13,7 @@ Command Palette Widget
 	'use strict';
 
 	var Widget = require('$:/core/modules/widgets/widget.js').widget;
+	var Utils = require("$:/core/modules/utils/utils.js");
 
 	class CommandPaletteWidget extends Widget {
 		constructor(parseTreeNode, options) {
@@ -741,7 +742,17 @@ Command Palette Widget
 
 		searchStepBuilder(filter, caret, hint) {
 			return (terms) => {
-				let search = filter.substr(0, caret) + terms + filter.substr(caret);
+				let search = "";
+				if (caret) {
+					// Use legacy "caret" logic
+					search = filter.substr(0, caret) + terms + filter.substr(caret);
+				}
+				else if (filter.indexOf("regexp[") !== -1 || filter.indexOf("regexp:title[") !== -1) {
+					search = filter.replace("%s", Utils.escapeRegExp(terms));
+				}
+				else {
+					search = filter.replace("%s", terms);
+				}
 				let results = $tw.wiki.filterTiddlers(search).map(s => { return { name: s, hint: hint } });
 				return results;
 			}

--- a/plugins/souk21/commandpalette/widgets_commandpalettewidget.js
+++ b/plugins/souk21/commandpalette/widgets_commandpalettewidget.js
@@ -13,7 +13,6 @@ Command Palette Widget
 	'use strict';
 
 	var Widget = require('$:/core/modules/widgets/widget.js').widget;
-	var Utils = require("$:/core/modules/utils/utils.js");
 
 	class CommandPaletteWidget extends Widget {
 		constructor(parseTreeNode, options) {
@@ -770,7 +769,7 @@ Command Palette Widget
 				}
 			};
 		}
-		
+
 		tagListProvider(terms) {
 			this.currentSelection = 0;
 			this.hint.innerText = 'Search tags';

--- a/plugins/souk21/commandpalette/widgets_commandpalettewidget.js
+++ b/plugins/souk21/commandpalette/widgets_commandpalettewidget.js
@@ -727,7 +727,14 @@ Command Palette Widget
 			}
 			else {
 				searches = this.searchSteps.reduce((a, c) => [...a, ...c(terms)], []);
-				searches = Array.from(new Set(searches));
+				let _unique = new Set();
+				// Filter search results to only get the first unique occurence of every tiddler name
+				searches = searches.filter(s => {
+					if (_unique.has(s.name))
+						return false;
+					_unique.add(s.name);
+					return true;
+				});
 			}
 			this.showResults(searches);
 		}

--- a/plugins/souk21/commandpalette/widgets_commandpalettewidget.js
+++ b/plugins/souk21/commandpalette/widgets_commandpalettewidget.js
@@ -748,10 +748,10 @@ Command Palette Widget
 					search = filter.substr(0, caret) + terms + filter.substr(caret);
 				}
 				else if (filter.indexOf("regexp") !== -1) {
-					search = filter.replace("%s", Utils.escapeRegExp(terms));
+					search = filter.replace(/%s/g, Utils.escapeRegExp(terms));
 				}
 				else {
-					search = filter.replace("%s", terms);
+					search = filter.replace(/%s/g, terms);
 				}
 				let results = $tw.wiki.filterTiddlers(search).map(s => { return { name: s, hint: hint } });
 				return results;

--- a/plugins/souk21/commandpalette/widgets_commandpalettewidget.js
+++ b/plugins/souk21/commandpalette/widgets_commandpalettewidget.js
@@ -747,7 +747,7 @@ Command Palette Widget
 					// Use legacy "caret" logic
 					search = filter.substr(0, caret) + terms + filter.substr(caret);
 				}
-				else if (filter.indexOf("regexp[") !== -1 || filter.indexOf("regexp:title[") !== -1) {
+				else if (filter.indexOf("regexp") !== -1) {
 					search = filter.replace("%s", Utils.escapeRegExp(terms));
 				}
 				else {


### PR DESCRIPTION
A variation of #19, with the difference that the search steps are defined using WikiText variables instead, and a query transform filter (idea from @EvidentlyCube).

With this code, my personal CommandPaletteSearchSteps looks like this:

```json
{
    "steps": [
          {"filter": "[!is[system]!is[image]regexp:title<query>]", "queryTransformFilter": "[<query>escaperegexp[]addprefix[(?i)\\b]]", "hint": "in title"},
          {"filter": "[!is[system]!is[image]search:title<query>]", "queryTransformFilter": "", "hint": "in title"},
          {"filter": "[!is[system]!is[image]regexp:text<query>]", "queryTransformFilter": "[<query>escaperegexp[]addprefix[(?i)\\b]]", "hint": "fulltext"},
          {"filter": "[!is[system]!is[image]search:text<query>]", "queryTransformFilter": "", "hint": "fulltext"},
          {"filter": "[!is[system]!is[image]search:*<query>]", "queryTransformFilter": "", "hint": "fields"},
          {"filter": "[is[image]search:title<query>]", "queryTransformFilter": "", "hint": "image"},
          {"filter": "[all[system+shadows]search:title<query>]", "queryTransformFilter": "", "hint": "in title (system)"},
          {"filter": "[all[system+shadows]search:text<query>]", "queryTransformFilter": "", "hint": "fulltext (system)"}
    ]
}
```

I assume that the method `makeFakeVariableWidget()` is not the best way to pass a variable to `filterTiddlers()`, so please let me know how to do it properly.